### PR TITLE
Make the generated `new` function public

### DIFF
--- a/codegen/src/worktable/generator/table.rs
+++ b/codegen/src/worktable/generator/table.rs
@@ -55,7 +55,7 @@ impl Generator {
         let new_impl = if self.is_persist {
             quote! {
                  impl #ident {
-                    fn new(manager:  std::sync::Arc<DatabaseManager>) -> Self {
+                    pub fn new(manager:  std::sync::Arc<DatabaseManager>) -> Self {
                         let mut inner = WorkTable::default();
                         inner.table_name = #table_name_lit;
                         Self(inner, manager)


### PR DESCRIPTION
@Handy-caT The `new` function is made public.