### PR TITLE
SelectBuilder where_by for any type non-indexed

### DIFF
--- a/codegen/src/worktable/generator/table/select_executor.rs
+++ b/codegen/src/worktable/generator/table/select_executor.rs
@@ -130,6 +130,17 @@ impl Generator {
             where
                 I: DoubleEndedIterator<Item = #row_type> + Sized,
             {
+
+                fn where_by<F>(self, predicate: F) -> SelectQueryBuilder<#row_type, impl DoubleEndedIterator<Item = #row_type>  + Sized, #column_range_type>
+                where
+                    F: FnMut(&#row_type) -> bool,
+                {
+                    SelectQueryBuilder {
+                        params: self.params,
+                        iter: self.iter.filter(predicate),
+                    }
+                }
+
                 fn execute(self) -> Result<Vec<#row_type>, WorkTableError> {
                     let mut iter: Box<dyn DoubleEndedIterator<Item = #row_type>> = Box::new(self.iter);
 

--- a/src/table/select/query.rs
+++ b/src/table/select/query.rs
@@ -3,7 +3,6 @@ use std::collections::VecDeque;
 use crate::select::{Order, QueryParams};
 use crate::WorkTableError;
 
-#[derive(Clone)]
 pub struct SelectQueryBuilder<Row, I, ColumnRange>
 where
     I: DoubleEndedIterator<Item = Row> + Sized,
@@ -43,7 +42,7 @@ where
         self
     }
 
-    pub fn where_by<R>(mut self, range: R, column: impl Into<String>) -> Self
+    pub fn range_by<R>(mut self, range: R, column: impl Into<String>) -> Self
     where
         R: Into<ColumnRange>,
     {
@@ -52,10 +51,16 @@ where
     }
 }
 
-pub trait SelectQueryExecutor<Row, I, T>
+pub trait SelectQueryExecutor<Row, I, ColumnRange>
 where
     Self: Sized,
     I: DoubleEndedIterator<Item = Row> + Sized,
 {
     fn execute(self) -> Result<Vec<Row>, WorkTableError>;
+    fn where_by<F>(
+        self,
+        predicate: F,
+    ) -> SelectQueryBuilder<Row, impl DoubleEndedIterator<Item = Row> + Sized, ColumnRange>
+    where
+        F: FnMut(&Row) -> bool;
 }

--- a/tests/worktable/base.rs
+++ b/tests/worktable/base.rs
@@ -569,7 +569,7 @@ fn select_all_range_test() {
 
     let all = table
         .select_all()
-        .where_by(0..2i64, "test")
+        .range_by(0..2i64, "test")
         .execute()
         .unwrap();
 
@@ -605,11 +605,146 @@ fn select_all_range_inclusive_test() {
 
     let all = table
         .select_all()
-        .where_by(0..=2i64, "test")
+        .range_by(0..=2i64, "test")
         .execute()
         .unwrap();
 
     assert_eq!(all.len(), 2);
+}
+
+#[test]
+fn select_all_where_by_eq_string_test() {
+    let table = TestWorkTable::default();
+
+    let row1 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 3,
+        another: 1,
+        exchange: "M1".to_string(),
+    };
+    let row2 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 1,
+        another: 2,
+        exchange: "N1".to_string(),
+    };
+    let row3 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 2,
+        another: 1,
+        exchange: "P1".to_string(),
+    };
+
+    let _ = table.insert(row1.clone()).unwrap();
+    let _ = table.insert(row2.clone()).unwrap();
+    let _ = table.insert(row3.clone()).unwrap();
+
+    let all = table.select_all();
+
+    let equal = all.where_by(|row| row.exchange.eq("P1")).execute().unwrap();
+    assert_eq!(equal.len(), 1);
+}
+
+#[test]
+fn select_all_where_by_contains_string_test() {
+    let table = TestWorkTable::default();
+
+    let row1 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 3,
+        another: 1,
+        exchange: "M1".to_string(),
+    };
+    let row2 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 1,
+        another: 2,
+        exchange: "N1".to_string(),
+    };
+    let row3 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 2,
+        another: 1,
+        exchange: "P1".to_string(),
+    };
+
+    let _ = table.insert(row1.clone()).unwrap();
+    let _ = table.insert(row2.clone()).unwrap();
+    let _ = table.insert(row3.clone()).unwrap();
+
+    let all = table.select_all();
+    let contains = all
+        .where_by(|row| row.exchange.contains("1"))
+        .execute()
+        .unwrap();
+
+    assert_eq!(contains.len(), 3);
+}
+
+#[test]
+fn select_all_where_by_gt_string_number_test() {
+    let table = TestWorkTable::default();
+
+    let row1 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 3,
+        another: 1,
+        exchange: "M1".to_string(),
+    };
+    let row2 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 1,
+        another: 2,
+        exchange: "N1".to_string(),
+    };
+    let row3 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 2,
+        another: 1,
+        exchange: "P1".to_string(),
+    };
+
+    let _ = table.insert(row1.clone()).unwrap();
+    let _ = table.insert(row2.clone()).unwrap();
+    let _ = table.insert(row3.clone()).unwrap();
+
+    let all = table.select_all();
+
+    let equal = all.where_by(|row| row.test > 1).execute().unwrap();
+    assert_eq!(equal.len(), 2);
+}
+
+#[test]
+fn select_all_where_by_eq_string_number_test() {
+    let table = TestWorkTable::default();
+
+    let row1 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 3,
+        another: 1,
+        exchange: "M1".to_string(),
+    };
+    let row2 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 1,
+        another: 2,
+        exchange: "N1".to_string(),
+    };
+    let row3 = TestRow {
+        id: table.get_next_pk().into(),
+        test: 2,
+        another: 1,
+        exchange: "P1".to_string(),
+    };
+
+    let _ = table.insert(row1.clone()).unwrap();
+    let _ = table.insert(row2.clone()).unwrap();
+    let _ = table.insert(row3.clone()).unwrap();
+
+    let all = table.select_all();
+
+    let equal = all.where_by(|row| row.another == 1).execute().unwrap();
+    assert_eq!(equal.len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
Add where_by for select builder; works with any column Accepts Fn 
Moved where_by to range_by (works with number columns)

Example: 

```rust
let all = table
        .select_all()
        .range_by(0..10, "test")
        .where_by(|row| row.exchange.contains("Test")
        .where_by(|row| row.exchange.eq("Test")
        .where_by(|row| row.test >= 100)
        .execute()
        .expect("rows");
```

Works as well for select_by_filed()