### PR TITLE
Refactor range_by -> range_on; order_by -> order_on

### DIFF
--- a/codegen/src/name_generator.rs
+++ b/codegen/src/name_generator.rs
@@ -29,6 +29,13 @@ impl WorktableNameGenerator {
         Ident::new(format!("{}Row", self.name).as_str(), Span::mixed_site())
     }
 
+    pub fn get_row_fields_ident(&self) -> Ident {
+        Ident::new(
+            format!("{}RowFields", self.name).as_str(),
+            Span::mixed_site(),
+        )
+    }
+
     pub fn get_available_type_ident(&self) -> Ident {
         Ident::new(
             format!("{}AvaiableTypes", self.name).as_str(),

--- a/codegen/src/worktable/generator/queries/select.rs
+++ b/codegen/src/worktable/generator/queries/select.rs
@@ -21,9 +21,14 @@ impl Generator {
         let name_generator = WorktableNameGenerator::from_table_name(self.name.to_string());
         let row_ident = name_generator.get_row_type_ident();
         let column_range_type = name_generator.get_column_range_type_ident();
+        let row_fields_enum = name_generator.get_row_fields_ident();
 
         quote! {
-            pub fn select_all(&self) -> SelectQueryBuilder<#row_ident, impl DoubleEndedIterator<Item = #row_ident> + '_ + Sized, #column_range_type> {
+            pub fn select_all(&self) -> SelectQueryBuilder<#row_ident,
+                                                           impl DoubleEndedIterator<Item = #row_ident> + '_ + Sized,
+                                                           #column_range_type,
+                                                           #row_fields_enum>
+            {
                 let iter = self.0.pk_map
                     .iter()
                     .filter_map(|(_, link)| self.0.data.select(*link).ok());

--- a/codegen/src/worktable/generator/row.rs
+++ b/codegen/src/worktable/generator/row.rs
@@ -1,7 +1,7 @@
 use crate::name_generator::WorktableNameGenerator;
 use crate::worktable::generator::Generator;
 use convert_case::{Case, Casing};
-use proc_macro2::{Ident, Literal, Span, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
 impl Generator {
@@ -10,13 +10,11 @@ impl Generator {
         let def = self.gen_row_type();
         let table_row_impl = self.gen_row_table_row_impl();
         let row_enum = self.gen_row_fields_enum();
-        let row_from = self.gen_row_fields_from_impl();
 
         quote! {
             #def
             #table_row_impl
             #row_enum
-            #row_from
         }
     }
 
@@ -116,38 +114,6 @@ impl Generator {
                 #(#rows)*
             }
         }
-    }
-
-    /// Generates impl from for `RowFields` enum.
-    fn gen_row_fields_from_impl(&self) -> TokenStream {
-        let name_generator = WorktableNameGenerator::from_table_name(self.name.to_string());
-        let ident = name_generator.get_row_type_ident();
-
-        let enum_name = Ident::new(format!("{ident}Fields").as_str(), Span::mixed_site());
-
-        let rows: Vec<_> = self
-            .columns
-            .columns_map
-            .keys()
-            .map(|name| {
-                let name_pascal = Ident::new(
-                    name.to_string().to_case(Case::Pascal).as_str(),
-                    Span::mixed_site(),
-                );
-                let name_lit = Literal::string(&name.to_string());
-                quote! { #enum_name::#name_pascal => #name_lit, }
-            })
-            .collect();
-
-        quote! {
-                    impl From<#enum_name> for &'static str {
-                        fn from(field: #enum_name) -> &'static str {
-                            match field {
-                               #(#rows)*
-                }
-            }
-        }
-                }
     }
 }
 

--- a/codegen/src/worktable/generator/table/index_fns.rs
+++ b/codegen/src/worktable/generator/table/index_fns.rs
@@ -13,6 +13,7 @@ impl Generator {
         let ident = name_generator.get_work_table_ident();
         let row_ident = name_generator.get_row_type_ident();
         let column_range_type = name_generator.get_column_range_type_ident();
+        let row_fields_enum = name_generator.get_row_fields_ident();
 
         let fn_defs = self
             .columns
@@ -28,6 +29,7 @@ impl Generator {
                         &self.columns.columns_map,
                         row_ident.clone(),
                         &column_range_type,
+                        &row_fields_enum,
                     )
                 }
             })
@@ -66,6 +68,7 @@ impl Generator {
         columns_map: &HashMap<Ident, TokenStream>,
         row_ident: Ident,
         column_range_type: &Ident,
+        row_fields_enum: &Ident,
     ) -> syn::Result<TokenStream> {
         let type_ = columns_map
             .get(i)
@@ -74,7 +77,11 @@ impl Generator {
         let field_ident = &idx.name;
 
         Ok(quote! {
-            pub fn #fn_name(&self, by: #type_) -> SelectQueryBuilder<#row_ident, impl DoubleEndedIterator<Item = #row_ident> + '_, #column_range_type> {
+            pub fn #fn_name(&self, by: #type_) -> SelectQueryBuilder<#row_ident,
+                                                                     impl DoubleEndedIterator<Item = #row_ident> + '_,
+                                                                     #column_range_type,
+                                                                     #row_fields_enum>
+            {
                 let rows: Vec<#row_ident> = self.0.indexes.#field_ident
                     .get(&by)
                     .into_iter()

--- a/src/table/select/mod.rs
+++ b/src/table/select/mod.rs
@@ -10,12 +10,10 @@ pub enum Order {
     Desc,
 }
 
-type Column = String;
-
 #[derive(Debug, Default, Clone)]
-pub struct QueryParams<ColumnRange> {
+pub struct QueryParams<ColumnRange, RowFields> {
     pub limit: Option<usize>,
     pub offset: Option<usize>,
-    pub order: VecDeque<(Order, Column)>,
-    pub range: VecDeque<(ColumnRange, Column)>,
+    pub order: VecDeque<(Order, RowFields)>,
+    pub range: VecDeque<(ColumnRange, RowFields)>,
 }

--- a/src/table/select/query.rs
+++ b/src/table/select/query.rs
@@ -37,16 +37,23 @@ where
         self
     }
 
-    pub fn order_by<S: Into<String>>(mut self, order: Order, column: S) -> Self {
-        self.params.order.push_back((order, column.into()));
+    pub fn order_on<O>(mut self, column: impl Into<&'static str>, order: O) -> Self
+    where
+        O: Into<Order>,
+    {
+        self.params
+            .order
+            .push_back((order.into(), column.into().to_string()));
         self
     }
 
-    pub fn range_by<R>(mut self, range: R, column: impl Into<String>) -> Self
+    pub fn range_on<R>(mut self, column: impl Into<&'static str>, range: R) -> Self
     where
         R: Into<ColumnRange>,
     {
-        self.params.range.push_back((range.into(), column.into()));
+        self.params
+            .range
+            .push_back((range.into(), column.into().to_string()));
         self
     }
 }

--- a/tests/worktable/base.rs
+++ b/tests/worktable/base.rs
@@ -583,7 +583,7 @@ fn select_all_range_test() {
 
     let all = table
         .select_all()
-        .range_by(0..2i64, "test")
+        .range_on(TestRowFields::Test, 0..2i64)
         .execute()
         .unwrap();
 
@@ -619,7 +619,7 @@ fn select_all_range_inclusive_test() {
 
     let all = table
         .select_all()
-        .range_by(0..=2i64, "test")
+        .range_on(TestRowFields::Test, 0..=2i64)
         .execute()
         .unwrap();
 
@@ -826,8 +826,8 @@ fn select_all_order_multiple_test() {
 
     let all = table
         .select_all()
-        .order_by(Order::Asc, "another")
-        .order_by(Order::Desc, "test")
+        .order_on(TestRowFields::Another, Order::Asc)
+        .order_on(TestRowFields::Test, Order::Desc)
         .execute()
         .unwrap();
 
@@ -926,7 +926,7 @@ fn select_all_order_by_unique_test() {
 
     let all = table
         .select_all()
-        .order_by(Order::Asc, "test")
+        .order_on(TestRowFields::Test, Order::Asc)
         .limit(2)
         .execute()
         .unwrap();
@@ -965,7 +965,7 @@ fn select_all_order_by_non_unique_test() {
 
     let all = table
         .select_all()
-        .order_by(Order::Asc, "exchange")
+        .order_on(TestRowFields::Exchange, Order::Asc)
         .limit(2)
         .execute()
         .unwrap();
@@ -1004,7 +1004,7 @@ fn select_all_order_two_test() {
 
     let all = table
         .select_all()
-        .order_by(Order::Asc, "test")
+        .order_on(TestRowFields::Test, Order::Asc)
         .limit(3)
         .execute()
         .unwrap();
@@ -1045,7 +1045,7 @@ fn select_by_order_by_test() {
 
     let all = table
         .select_by_exchange("c_test".to_string())
-        .order_by(Order::Desc, "test")
+        .order_on(TestRowFields::Test, Order::Desc)
         .limit(3)
         .execute()
         .expect("rows");
@@ -1088,7 +1088,7 @@ fn select_by_offset_test() {
 
     let all = table
         .select_by_exchange("c_test".to_string())
-        .order_by(Order::Desc, "test")
+        .order_on(TestRowFields::Test, Order::Desc)
         .offset(10)
         .limit(3)
         .execute()


### PR DESCRIPTION
Add generated RowFileds enum 
Changed params for order_on, range_on 

For now we replacing passing row.attr from &str to enum invariant, for more strict type check

```
let all = table
        .select_all()
        .range_on(TestRowFields::Test, 0..=2i64)
        .execute()
```


```
let all = table
        .select_all()
        .order_on(TestRowFields::Exchange, Order::Desc)
        .execute()
```


