### PR TITLE
fix: flush space files before an operation reports done (CI golden-file flake)

### DIFF
--- a/src/persistence/space/data.rs
+++ b/src/persistence/space/data.rs
@@ -115,7 +115,12 @@ where
         }
         self.current_data_length += link.length;
         self.update_data_length().await?;
-        update_at::<{ PAGE_SIZE }>(&mut self.data_file, link, bytes).await
+        update_at::<{ PAGE_SIZE }>(&mut self.data_file, link, bytes).await?;
+        // `update_at` ends with a buffered `write_all` that `tokio::fs::File`
+        // completes on a background blocking task. Flush before reporting the
+        // save done so the bytes are visible to any other handle.
+        self.data_file.flush().await?;
+        Ok(())
     }
 
     async fn save_batch_data(&mut self, batch_data: BatchData) -> eyre::Result<()> {
@@ -171,6 +176,9 @@ where
             .collect::<Result<Vec<_>, _>>()?;
 
         persist_pages_batch(updated_pages, &mut self.data_file).await?;
+        // The batch's last page write is a buffered `write_all`; flush so the
+        // batch is visible to other handles once it reports done.
+        self.data_file.flush().await?;
 
         Ok(())
     }

--- a/src/persistence/space/index/mod.rs
+++ b/src/persistence/space/index/mod.rs
@@ -27,6 +27,7 @@ use rkyv::ser::sharing::Share;
 use rkyv::util::AlignedVec;
 use rkyv::{Archive, Deserialize, Serialize, rancor};
 use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
 
 use crate::persistence::SpaceIndexOps;
 use crate::persistence::space::{BatchChangeEvent, open_or_create_file};
@@ -373,7 +374,13 @@ where
                 max_value: node_id,
                 split_index,
             } => self.process_split_node(node_id, split_index).await,
-        }
+        }?;
+        // The partial page writes above can end with a buffered `write_all`
+        // that `tokio::fs::File` completes on a background blocking task.
+        // Flush before reporting the event processed so the bytes are visible
+        // to any other handle that opens this file afterwards.
+        self.index_file.flush().await?;
+        Ok(())
     }
 
     async fn process_change_event_batch(&mut self, events: BatchChangeEvent<T>) -> eyre::Result<()> {
@@ -490,6 +497,9 @@ where
 
         self.table_of_contents.persist(&mut self.index_file).await?;
         persist_pages_batch(pages.values().cloned().collect(), &mut self.index_file).await?;
+        // The batch's last page write is a buffered `write_all`; flush so the
+        // batch is visible to other handles once it reports done.
+        self.index_file.flush().await?;
         Ok(())
     }
 }

--- a/src/persistence/space/index/unsized_.rs
+++ b/src/persistence/space/index/unsized_.rs
@@ -21,6 +21,7 @@ use rkyv::ser::sharing::Share;
 use rkyv::util::AlignedVec;
 use rkyv::{Archive, Deserialize, Serialize, rancor};
 use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
 
 use crate::UnsizedNode;
 use crate::persistence::space::BatchChangeEvent;
@@ -318,7 +319,13 @@ where
                 max_value: node_id,
                 split_index,
             } => self.process_split_node(node_id, split_index).await,
-        }
+        }?;
+        // The partial page writes above can end with a buffered `write_all`
+        // that `tokio::fs::File` completes on a background blocking task.
+        // Flush before reporting the event processed so the bytes are visible
+        // to any other handle that opens this file afterwards.
+        self.index_file.flush().await?;
+        Ok(())
     }
 
     async fn process_change_event_batch(&mut self, events: BatchChangeEvent<T>) -> eyre::Result<()> {
@@ -436,6 +443,9 @@ where
 
         self.table_of_contents.persist(&mut self.index_file).await?;
         persist_pages_batch(pages.values().cloned().collect(), &mut self.index_file).await?;
+        // The batch's last page write is a buffered `write_all`; flush so the
+        // batch is visible to other handles once it reports done.
+        self.index_file.flush().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## What broke on CI

[Run 30225242525](https://github.com/pathscale/WorkTable/actions/runs/30225242525/job/89854259774) (the `release: 0.9.0` push) failed in
`persistence::space_index::write::run_first::test_space_index_process_insert_at`: the golden-file
comparison against `tests/data/expected/space_index/process_insert_at.wt.idx` mismatched.

This is not a regression from the 0.9.0 release commit — that commit only touched version
metadata, the README, and an unrelated fixture. It is a long-standing flake: the pre-series red
on `62a0ddb` ([run 30203664405](https://github.com/pathscale/WorkTable/actions/runs/30203664405)) failed the *unsized* variant of the same test the same way,
and `main` had been red for months. The 15-patch series turned CI green on `b1d0e0f`; the 0.9.0
run then rolled the dice on the one remaining flake and lost.

## Root cause: operations report done while their last write is still in flight

`tokio::fs::File::write_all` does not write to the OS — it copies the bytes into the file
handle's internal buffer, spawns a background blocking task to perform the syscall, and returns
immediately. Any *subsequent* operation on the same handle (seek, stream_position, flush) drains
the in-flight write first, but if `write_all` is the **last** thing an operation does, the
operation returns while the bytes are still in tokio's buffer.

Three write paths end exactly like that:

- `SpaceIndex::process_insert_at` / `process_remove_at` end with data_bucket's
  `persist_index_page_utility`, which ends with a bare `write_all` (both sized and unsized).
- `process_change_event_batch` ends with `persist_pages_batch`, whose final page write is a bare
  `write_all`.
- `SpaceData::save_data` ends with `update_at` (bare `write_all` after a seek), and
  `save_batch_data` ends with `persist_pages_batch`.

A reader using a **different** file handle — the test's `std::fs::File` comparison, or a table
reload — can then observe stale bytes until the blocking pool gets around to the write. On a
fast idle machine the window is microseconds and the tests pass; on a loaded 4-vCPU CI runner
the blocking pool lags and the comparison wins the race.

Evidence this is the mechanism (and not a content bug):

- Reproduced locally at ~10% per suite run by running the suite alongside 12 CPU burners; the
  failures rotate among exactly the `insert_at`-family tests (sized, unsized, and
  `indexset_compatibility` variants) — the ones whose last write is a bare `write_all`.
  The `create_node` tests, which end in `persist_page` (whose trailing `stream_position`/`seek`
  forces the write to complete), have never flaked.
- A byte-level snapshot of the "mismatched" working file taken right after a failing run is
  **identical** to the expected fixture — the file converges as soon as the background write
  lands. The content was never wrong; it just wasn't there yet.

## Fix

Flush the file handle at the operation boundaries that could previously return with a write in
flight: `process_change_event` and `process_change_event_batch` (sized and unsized index), and
`SpaceData::save_data` / `save_batch_data`. `flush` on `tokio::fs::File` waits for the pending
background write to complete — it is **not** an fsync (no durability cost), it only guarantees
the bytes reached the OS before the operation reports success. When the handle is idle it is a
no-op.

This also tightens the persistence engine's semantics: `apply_batch_operation` no longer
"completes" a batch whose final page write hasn't reached the file, which matters for
`wait_for_ops`-then-reload flows.

## Validation

Controlled A/B on one machine — `cargo test --test mod` in a loop alongside 12 CPU-burner
processes, same load for both sides:

| build | failed runs | space_index failures |
|---|---|---|
| `master` (7ebb42f) | 6 / 25 | 5 (sized + unsized + compat `insert_at` variants) |
| this branch | **0 / 25** | **0** |

An additional 50 runs of the fixed build under roughly double that load (a mistake in my
harness left ~24 burners running) still produced **0** space_index failures — only known
pre-existing lock-free-insert-family flakes surfaced there (`update_parallel*`, `in_place`,
`vacuum_parallel_with_upserts`, `delete_parallel`, and panics inside `indexset-0.16.0`, which
data_bucket 0.4.0 still pulls in alongside `WorkTablesIndex`). Same class as the `#[ignore]`d
upsert churn tests / #169; not addressed here.

`cargo fmt` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
