### PR TITLE
ci: trigger the Rust workflow on master

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "master" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The workflow's `push`/`pull_request` triggers only listed `main`, but the repository's only branch (and GitHub default) is `master`. Result: pushes to master and PRs targeting it run **no checks at all** — https://github.com/pathscale/WorkTable/pull/171 was merged with "no checks reported", and the merge commit `c94e9a7` on master started no run either. The historical runs all carry `head_branch: main`, so CI went dark whenever that branch stopped being pushed.

This adds `master` to both triggers (keeping `main` in case of a future rename). Once merged, the next push to master will produce the first CI verdict on the flush fix.

Relevant to the 0.9.0 release: the working agreement gates `cargo publish` on a green merged default branch, which is impossible while CI never runs on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)