### PR TITLE
build: publish the codegen crate as worktable_macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,10 @@ tracing = "0.1"
 url = { version = "2", optional = true }
 uuid = { version = "1.10.0", features = ["v4", "v7"] }
 walkdir = { version = "2", optional = true }
-worktable_codegen = { path = "codegen", version = "=0.9.0" }
+# Renamed dependency: the package on crates.io is `worktable_macros`
+# (worktable_codegen's ownership is unavailable), but the lib target and
+# every `use worktable_codegen::...` keep the original name.
+worktable_codegen = { package = "worktable_macros", path = "codegen", version = "=0.9.0" }
 
 [dev-dependencies]
 chrono = "0.4.43"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "worktable_codegen"
+name = "worktable_macros"
 version = "0.9.0"
 edition = "2024"
 license = "MIT"
-description = "WorkTable codegeneration crate"
+description = "Proc-macro companion crate for worktable: the worktable! macro and its derives. Formerly published as worktable_codegen."
+repository = "https://github.com/pathscale/WorkTable"
 
 [features]
 s3-support = []


### PR DESCRIPTION
Unblocks the 0.9.0 release. `worktable_codegen` on crates.io has a single external owner (Handy-caT), so this project cannot publish `worktable_codegen 0.9.0` — and `worktable` pins `=0.9.0`, so the release was stuck.

Rename the package to `worktable_macros` (the conventional name for a proc-macro companion crate — tokio-macros, pyo3-macros) and publish under that name, which is unclaimed.

Only the package name changes:
- the lib target keeps the `worktable_codegen` name, and
- the root manifest uses a renamed dependency (`worktable_codegen = { package = "worktable_macros", ... }`),

so every `use worktable_codegen::…` and the `worktable_codegen/s3-support` feature reference stay untouched. Zero source changes.

Verified: full suite green (316 passed), `cargo fmt` / `clippy --all-targets` clean, `cargo publish --dry-run -p worktable_macros` packages and compiles.

Release sequence after merge: publish `worktable_macros 0.9.0` → publish `worktable 0.9.0` → tag `v0.9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)